### PR TITLE
[김동규] #13 가계부 카테고리 생성/조회 기능 구현

### DIFF
--- a/account_books/api/books.py
+++ b/account_books/api/books.py
@@ -1,8 +1,9 @@
 from ninja import Router
 
+from typing import Optional, List
+
 from django.http      import JsonResponse
 from django.db.models import Q
-from typing           import Optional, List
 
 from core.schema                    import ErrorMessage
 from core.utils.auth                import AuthBearer

--- a/account_books/api/categories.py
+++ b/account_books/api/categories.py
@@ -1,0 +1,100 @@
+from ninja import Router
+
+from typing import Optional, List
+
+from django.http      import JsonResponse
+from django.db.models import Q
+
+from core.utils.auth import AuthBearer
+from core.schema     import ErrorMessage
+
+from account_books.schema import AccountBookCategoryCreateInput, AccountBookCategoryOutput
+from account_books.models import AccountBookCategory
+
+
+router = Router()
+
+
+"""
+가계부 카테고리 조회 API
+"""
+@router.get(
+    '',
+    tags     = ['3. 가계부 카테고리'],
+    summary  = '가계부 카테고리 리스트 조회',
+    response = List[AccountBookCategoryOutput],
+    auth     = AuthBearer()
+)
+def get_list_account_book_categories(
+    request,
+    search: Optional[str] = None,
+    sort  : str = 'up_to_date',
+    status: str = 'deleted',
+    offset: int = 0,
+    limit : int = 10
+    ):
+    
+    """
+    JWT 토큰에서 유저정보 추출
+    """
+    user = request.auth
+
+    """
+    정렬 기준
+    """
+    sort_set = {
+        'up_to_date' : '-created_at',
+        'out_of_date': 'created_at'
+    }
+    
+    """
+    Q 객체 활용:
+        - 검색 기능(가계부 카테고리 이름을 기준으로 검색 필터링)
+        - 필터링 기능(본인의 카테고리 필터링)
+    """
+    q = Q()
+    
+    if search:
+        q |= Q(name__icontains=search)
+    if user:
+        q &= Q(user=user)
+    
+    categories = AccountBookCategory.objects\
+                                    .select_related('user')\
+                                    .filter(q)\
+                                    .exclude(status__iexact=status)\
+                                    .order_by(sort_set[sort])[offset:offset+limit]
+                                    
+    return categories
+
+
+"""
+가계부 카테고리 생성 API
+"""
+@router.post(
+    '',
+    tags     = ['3. 가계부 카테고리'],
+    summary  = '가계부 카테고리 생성',
+    response = {200: AccountBookCategoryOutput, 400: ErrorMessage},
+    auth     = AuthBearer()
+)
+def create_account_book_category(request, data: AccountBookCategoryCreateInput):
+    
+    """
+    JWT 토큰에서 유저정보 추출
+    """
+    user = request.auth
+    
+    """
+    가계부 카테고리 이름 필수값 확인
+    """
+    name = data.name
+    if not name:
+        return JsonResponse({'detail': '가계부 카테고리 이름은 필수 입력값입니다.'}, status=400)
+    
+    category = AccountBookCategory.objects\
+                                  .create(
+                                      user = user,
+                                      name = name
+                                  )
+    return category

--- a/account_books/schema.py
+++ b/account_books/schema.py
@@ -27,3 +27,21 @@ class AccountBookOutput(Schema):
         if not obj.user.nickname:
             return None
         return obj.user.nickname
+    
+
+class AccountBookCategoryCreateInput(Schema):
+    name  : str
+    status: Optional[str] = 'in_use'
+
+
+class AccountBookCategoryOutput(Schema):
+    id      : int
+    nickname: Optional[str] = None
+    name    : str
+    status  : str
+    
+    @staticmethod
+    def resolve_nickname(obj):
+        if not obj.user.nickname:
+            return None
+        return obj.user.nickname

--- a/config/api.py
+++ b/config/api.py
@@ -1,10 +1,12 @@
 from ninja import NinjaAPI
 
-from users.api               import router as users_router
-from account_books.api.books import router as account_books_router
+from users.api                    import router as users_router
+from account_books.api.books      import router as account_books_router
+from account_books.api.categories import router as account_book_categories_router
 
 
 api = NinjaAPI()
 
 api.add_router('/users', users_router)
 api.add_router('/account-books', account_books_router)
+api.add_router('/account-books/categories', account_book_categories_router)


### PR DESCRIPTION
<!--PR 제목 : [ 이름 ] #이슈번호 - 구현 내용 -->

# 구현 목표
<!-- 이슈 번호 맵핑해주세요. 간단한 요약을 해주세요.-->
- #13 
- 가계부 카테고리 생성/(리스트)조회 기능 구현

# 변경 사항
<!--관련 없는 내용을 지워주세요-->

- [x] 기능 추가
- [ ] 셋업 
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 코드리뷰 반영
- [ ] 컨벤션 수정
- [ ] 레거시코드 제거 및 Breaking

<!--⬇ 변경사항을 자세히 작성합니다. ⬇-->
- 가계부 카테고리 생성 기능 구현
   - 인증/인가에 통과한 유저만 가계부 카테고리 생성 가능
   - 필수 입력값(카테고리 이름) 확인
- 가계부 카테고리 리스트 조회 기능 구현
   - 인증/인가에 통과한 유저만 본인의 가계부 카테고리 리스트 조회 가능
   - 부가기능:
      - 카테고리 검색기능
      - 카테고리 정렬기능
      - 카테고리 필터링기능(사용중인/삭제된 가계부)
      - 페이지네이션 기능

# 테스트 여부
<!--테스트 통과 여부를 체크해주세요-->
- [x] TEST 

# 스크린샷 
<!--필요한 경우 첨부합니다-->

