### PR TITLE
[김동규] #13 가계부 카테고리 수정/삭제/복구 기능 구현

### DIFF
--- a/account_books/api/categories.py
+++ b/account_books/api/categories.py
@@ -2,13 +2,14 @@ from ninja import Router
 
 from typing import Optional, List
 
-from django.http      import JsonResponse
+from django.http      import HttpRequest, JsonResponse
 from django.db.models import Q
 
-from core.utils.auth import AuthBearer
-from core.schema     import ErrorMessage
+from core.schema                    import ErrorMessage
+from core.utils.auth                import AuthBearer
+from core.utils.get_obj_n_check_err import GetAccountBookCategory
 
-from account_books.schema import AccountBookCategoryCreateInput, AccountBookCategoryOutput
+from account_books.schema import AccountBookCategoryCreateInput, AccountBookCategoryUpdateInput, AccountBookCategoryOutput
 from account_books.models import AccountBookCategory
 
 
@@ -26,13 +27,13 @@ router = Router()
     auth     = AuthBearer()
 )
 def get_list_account_book_categories(
-    request,
-    search: Optional[str] = None,
-    sort  : str = 'up_to_date',
-    status: str = 'deleted',
-    offset: int = 0,
-    limit : int = 10
-    ):
+    request: HttpRequest,
+    search : Optional[str] = None,
+    sort   : str = 'up_to_date',
+    status : str = 'deleted',
+    offset : int = 0,
+    limit  : int = 10
+    ) -> JsonResponse:
     
     """
     JWT 토큰에서 유저정보 추출
@@ -78,7 +79,10 @@ def get_list_account_book_categories(
     response = {200: AccountBookCategoryOutput, 400: ErrorMessage},
     auth     = AuthBearer()
 )
-def create_account_book_category(request, data: AccountBookCategoryCreateInput):
+def create_account_book_category(
+    request: HttpRequest, 
+    data   : AccountBookCategoryCreateInput
+    ) -> JsonResponse:
     
     """
     JWT 토큰에서 유저정보 추출
@@ -98,3 +102,111 @@ def create_account_book_category(request, data: AccountBookCategoryCreateInput):
                                       name = name
                                   )
     return category
+
+
+"""
+가계부 카테고리 수정 API
+"""
+@router.patch(
+    '/{int:account_book_category_id}',
+    tags     = ['3. 가계부 카테고리'],
+    summary  = '가계부 카테고리 수정',
+    response = {200: AccountBookCategoryOutput, 400: ErrorMessage},
+    auth     = AuthBearer()
+)
+def update_account_book_category(
+    request: HttpRequest, 
+    data   : AccountBookCategoryUpdateInput, 
+    account_book_category_id: int
+    ) -> JsonResponse:
+    
+    """
+    JWT 토큰에서 유저정보 추출
+    """
+    user = request.auth
+
+    """
+    가계부 카테고리 객체/유저정보 확인
+    """
+    category, err = GetAccountBookCategory.get_category_n_check_error(account_book_category_id, user)
+    if err:
+        return JsonResponse({'detail': err}, status=400)
+    
+    if data.name:
+        category.name = data.name
+        
+    category.save()
+
+    return category
+
+
+"""
+가계부 카테고리 삭제 API
+"""
+@router.delete(
+    '/{int:account_book_category_id}',
+    tags     = ['3. 가계부 카테고리'],
+    summary  = '가계부 카테고리 삭제',
+    response = {204: None, 400: ErrorMessage},
+    auth     = AuthBearer()
+)
+def delete_account_book_category(
+    request: HttpRequest, 
+    account_book_category_id: int
+    ) -> JsonResponse:
+    
+    """
+    JWT 토큰에서 유저정보 추출
+    """
+    user = request.auth
+
+    """
+    가계부 카테고리 객체/유저정보 확인
+    """
+    category, err = GetAccountBookCategory.get_category_n_check_error(account_book_category_id, user)
+    if err:
+        return JsonResponse({'detail': err}, status=400)
+    
+    if category.status == 'deleted':
+        return JsonResponse({'detail': f'가계부 카테고리 {account_book_category_id}(id)은/는 이미 삭제된 상태입니다.'}, status=400)
+
+    category.status = 'deleted'
+    category.save()
+
+    return 204, None
+
+
+"""
+가계부 카테고리 복구 API
+"""
+@router.patch(
+    '/{int:account_book_category_id}/restore',
+    tags = ['3. 가계부 카테고리'],
+    summary = '가계부 카테고리 복구',
+    response = {204: None, 400: ErrorMessage},
+    auth = AuthBearer()
+)
+def restore_account_book_category(
+    request: HttpRequest,
+    account_book_category_id: int
+    ) -> JsonResponse:
+    
+    """
+    JWT 토큰에서 유저정보 추출
+    """
+    user = request.auth
+
+    """
+    가계부 카테고리 객체/유저정보 확인
+    """
+    category, err = GetAccountBookCategory.get_category_n_check_error(account_book_category_id, user)
+    if err:
+        return JsonResponse({'detail': err}, status=400)
+    
+    if category.status == 'in_use':
+        return JsonResponse({'detail': f'가계부 카테고리 {account_book_category_id}(id)은/는 이미 복구된 상태입니다.'}, status=400)
+
+    category.status = 'in_use'
+    category.save()
+
+    return 204, None

--- a/account_books/schema.py
+++ b/account_books/schema.py
@@ -34,6 +34,10 @@ class AccountBookCategoryCreateInput(Schema):
     status: Optional[str] = 'in_use'
 
 
+class AccountBookCategoryUpdateInput(Schema):
+    name: Optional[str] = None
+    
+
 class AccountBookCategoryOutput(Schema):
     id      : int
     nickname: Optional[str] = None

--- a/core/utils/get_obj_n_check_err.py
+++ b/core/utils/get_obj_n_check_err.py
@@ -1,6 +1,6 @@
 from typing import Tuple, Any
 
-from account_books.models import AccountBook
+from account_books.models import AccountBook, AccountBookCategory
 from users.models         import User
 
 
@@ -29,3 +29,29 @@ class GetAccountBook:
             return None, '다른 유저의 가계부입니다.'
         
         return book, None
+    
+
+class GetAccountBookCategory:
+    """
+    description:
+        - 가계부 카테고리 id를 통해 카테고리 객체(정보)의 존재여부 확인
+        - 가계부 카테고리 객체의 유저정보와 API를 요청한 유저정보가 일치하는지 확인
+    """
+    
+    def get_category_n_check_error(account_book_category_id: int, user: User) -> Tuple[Any, str]:
+        """
+        카테고리 존재여부 확인
+        """
+        try:
+            category = AccountBookCategory.objects\
+                                          .get(id=account_book_category_id)
+        except AccountBookCategory.DoesNotExist:
+            return None, f'가계부 카테고리 {account_book_category_id}(id)는 존재하지 않습니다.'
+        
+        """
+        본인의 카테고리인지 확인
+        """
+        if not user.nickname == category.user.nickname:
+            return None, '다른 유저의 가계부 카테고리입니다.'
+        
+        return category, None


### PR DESCRIPTION
<!--PR 제목 : [ 이름 ] #이슈번호 - 구현 내용 -->

# 구현 목표
<!-- 이슈 번호 맵핑해주세요. 간단한 요약을 해주세요.-->
- #13 
- 가계부 카테고리 수정/삭제/복구 기능 구현

# 변경 사항
<!--관련 없는 내용을 지워주세요-->

- [x] 기능 추가
- [ ] 셋업 
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 코드리뷰 반영
- [ ] 컨벤션 수정
- [ ] 레거시코드 제거 및 Breaking

<!--⬇ 변경사항을 자세히 작성합니다. ⬇-->
- 가계부 카테고리 수정 기능
   - 인증/인가에 통과한 유저만 본인의 가계부 카테고리 수정 가능
   - 카테고리의 이름만 수정 가능
   - 수정 요청한 카테고리가 존재하는지 확인
   - 수정 요청한 카테고리가 본인의 가계부인지 확인
- 가계부 카테고리 삭제 기능
   - 인증/인가에 통과한 유저만 본인의 가계부 카테고리 삭제 가능
   - 삭제 요청한 카테고리가 존재하는지 확인
   - 삭제 요청한 카테고리가 본인의 가계부인지 확인
   - 이미 삭제된 카테고리인지 확인
- 가계부 카테고리 복구 기능
   - 인증/인가에 통과한 유저만 본인의 가계부 카테고리 복구 가능
   - 복구 요청한 카테고리가 존재하는지 확인
   - 복구 요청한 카테고리가 본인의 가계부인지 확인
   - 이미 복구된 카테고리인지 확인

# 테스트 여부
<!--테스트 통과 여부를 체크해주세요-->
- [x] TEST 

# 스크린샷 
<!--필요한 경우 첨부합니다-->

