### PR TITLE
[김동규] #16 가계부 기록 생성/조회 기능 구현

### DIFF
--- a/account_books/api/logs.py
+++ b/account_books/api/logs.py
@@ -1,0 +1,184 @@
+from ninja import Router
+
+from typing import Optional
+
+from django.http      import HttpRequest, JsonResponse
+from django.db.models import Q, Sum
+
+from core.schema                    import ErrorMessage
+from core.utils.auth                import AuthBearer
+from core.utils.get_obj_n_check_err import GetAccountBook, GetAccountBookCategory
+
+from account_books.schema import AccountBookLogCreateInput, AccountBookLogCreateOutput, AccountBookLogListOutput
+from account_books.models import AccountBookLog
+
+
+router = Router()
+
+
+"""
+가계부 기록 조회 API
+"""
+@router.get(
+    '',
+    tags     = ['4. 가계부 기록'],
+    summary  = '가계부 기록 리스트 조회',
+    response = AccountBookLogListOutput,
+    auth     = AuthBearer()
+)
+def get_list_account_book_log(
+    request    : HttpRequest,
+    book_id    : int,
+    cateogry_id: Optional[str] = None,
+    search     : Optional[str] = None,
+    types      : Optional[str] = None,
+    sort       : str = 'up_to_date',
+    status     : str = 'deleted',
+    offset     : int = 0,
+    limit      : int = 10
+    ) -> JsonResponse:
+    
+    """
+    JWT 토큰에서 유저정보 추출
+    """
+    user = request.auth
+
+    """
+    정렬 기준
+    """
+    sort_set = {
+        'up_to_date' : '-created_at',
+        'out_of_date': 'created_at',
+        'high_price' : '-price',
+        'low_price'  : 'price',    
+    }
+    
+    """
+    가계부 id 필수값 확인
+    """
+    account_book_id = book_id
+    if not account_book_id:
+        return JsonResponse({'detail': '가계부는 필수 입력값입니다.'}, status=400)
+    
+    """
+    가계부 객체/유저정보 확인
+    """
+    book, err = GetAccountBook.get_book_n_check_error(account_book_id, user)
+    if err:
+        return JsonResponse({'detail': err}, status=400)
+    
+    """
+    Q 객체 활용:
+        - 검색 기능(가계부 기록 제목/설명/카테고리를 기준으로 검색 필터링)
+        - 필터링 기능(가계부 기록 카테고리/타입을 기준으로 필터링)
+        - 필터링 기능(본인의 가계부 기록 필터링)
+    """
+    q = Q()
+    
+    if search:
+        q |= Q(title__icontains = search)
+        q |= Q(description__icontains = search)
+        q |= Q(category__name__icontains = search)
+    if account_book_id:
+        q &= Q(book_id = book.id)
+    if cateogry_id:
+        categories = cateogry_id.split(',')
+        q &= Q(category_id__in = categories)
+    if types:
+        q &= Q(types__iexact = types)
+        
+    logs = AccountBookLog.objects\
+                         .select_related('category', 'book')\
+                         .filter(q)\
+                         .exclude(status__iexact=status)\
+                         .order_by(sort_set[sort])
+    
+    """
+    총수입/총지출 기록 산출
+    """                      
+    income      = logs.filter(types='income').aggregate(total=Sum('price'))
+    expenditure = logs.filter(types='expenditure').aggregate(total=Sum('price'))
+    
+    """
+    가계부 기록 반환 데이터(페이지네이션 기능 포함)
+    """
+    data = {
+        'nickname'         : user.nickname,
+        'expected_budget'  : book.budget,
+        'total_income'     : income['total'],
+        'total_expenditure': expenditure['total'],
+        'logs'             : list(logs)[offset:offset+limit]
+    }
+    
+    return data
+    
+
+"""
+가계부 기록 생성 API
+"""
+@router.post(
+    '',
+    tags     = ['4. 가계부 기록'],
+    summary  = '가계부 기록 생성',
+    response = {200: AccountBookLogCreateOutput, 400: ErrorMessage},
+    auth     = AuthBearer()
+)
+def create_account_book_log(
+    request: HttpRequest,
+    data   : AccountBookLogCreateInput
+    ) -> JsonResponse:
+    
+    """
+    JWT 토큰에서 유저정보 추출
+    """
+    user = request.auth
+    
+    """
+    필수값 확인:
+        - 가계부 id
+        - 가계부 카테고리 id
+        - 가계부 기록 제목/타입/가격/설명
+    """
+    account_book_id = data.book_id
+    if not account_book_id:
+        return JsonResponse({'detail': '가계부는 필수 입력값입니다.'}, status=400)
+    account_book_category_id = data.cateogry_id
+    if not account_book_category_id:
+        return JsonResponse({'detail': '가계부 카테고리는 필수 입력값입니다.'}, status=400)
+    title = data.title
+    if not title:
+        return JsonResponse({'detail': '가계부 기록 제목은 필수 입력값입니다.'}, status=400)
+    types = data.types
+    if not types:
+        return JsonResponse({'detail': '가계부 기록 타입은 필수 입력값입니다.'}, status=400)
+    price = data.price
+    if price is None:
+        return JsonResponse({'detail': '가계부 기록 가격은 필수 입력값입니다.'}, status=400)
+    description = data.description
+    if not description:
+        return JsonResponse({'detail': '가계부 기록 설명은 필수 입력값입니다.'}, status=400)
+    
+    """
+    가계부 객체/유저정보 확인
+    """
+    book, err = GetAccountBook.get_book_n_check_error(account_book_id, user)
+    if err:
+        return JsonResponse({'detail': err}, status=400)
+    
+    """
+    가계부 카테고리 객체/유저정보 확인
+    """
+    category, err = GetAccountBookCategory.get_category_n_check_error(account_book_category_id, user)
+    if err:
+        return JsonResponse({'detail': err}, status=400)
+    
+    log = AccountBookLog.objects\
+                        .create(
+                            book        = book,
+                            category    = category,
+                            title       = title,
+                            price       = price,
+                            description = description,
+                            types       = types               
+                        ) 
+    return log    

--- a/account_books/schema.py
+++ b/account_books/schema.py
@@ -1,4 +1,4 @@
-from typing  import Optional
+from typing  import Optional, List
 from decimal import Decimal
 
 from ninja import Schema
@@ -49,3 +49,86 @@ class AccountBookCategoryOutput(Schema):
         if not obj.user.nickname:
             return None
         return obj.user.nickname
+    
+    
+class AccountBookLogCreateInput(Schema):
+    title: str
+    types: str
+    price: int
+    description: str
+    cateogry_id: int
+    book_id    : int
+    
+    
+class AccountBookLogCreateOutput(Schema):
+    id   : int
+    title: str
+    types: str
+    price: int
+    description: str
+    status     : str
+    book       : str
+    category   : str
+    created_at : str
+    updated_at : str
+    
+    @staticmethod
+    def resolve_book(obj):
+        return obj.book.name
+    
+    @staticmethod
+    def resolve_category(obj):
+        if obj.category.status == 'deleted':
+            category = None
+        else:
+            category = obj.category.name
+        return category
+    
+    @staticmethod
+    def resolve_created_at(obj):
+        return (obj.created_at).strftime('%Y-%m-%d %H:%M')
+    
+    @staticmethod
+    def resolve_updated_at(obj):
+        return (obj.updated_at).strftime('%Y-%m-%d %H:%M')
+    
+    
+class AccountBookLogOutput(Schema):
+    id   : int
+    title: str
+    types: str
+    price: int
+    description: str
+    status     : str
+    book       : str
+    category   : str
+    created_at : str
+    updated_at : str
+    
+    @staticmethod
+    def resolve_book(obj):
+        return obj.book.name
+    
+    @staticmethod
+    def resolve_category(obj):
+        if obj.category.status == 'deleted':
+            category = None
+        else:
+            category = obj.category.name
+        return category
+    
+    @staticmethod
+    def resolve_created_at(obj):
+        return (obj.created_at).strftime('%Y-%m-%d %H:%M')
+    
+    @staticmethod
+    def resolve_updated_at(obj):
+        return (obj.updated_at).strftime('%Y-%m-%d %H:%M')
+    
+    
+class AccountBookLogListOutput(Schema):
+    nickname         : str
+    expected_budget  : int
+    total_income     : Optional[int] = None
+    total_expenditure: Optional[int] = None
+    logs: Optional[List[AccountBookLogOutput]] = None

--- a/config/api.py
+++ b/config/api.py
@@ -3,6 +3,7 @@ from ninja import NinjaAPI
 from users.api                    import router as users_router
 from account_books.api.books      import router as account_books_router
 from account_books.api.categories import router as account_book_categories_router
+from account_books.api.logs       import router as account_book_logs_router
 
 
 api = NinjaAPI()
@@ -10,3 +11,4 @@ api = NinjaAPI()
 api.add_router('/users', users_router)
 api.add_router('/account-books', account_books_router)
 api.add_router('/account-books/categories', account_book_categories_router)
+api.add_router('/account-books/logs', account_book_logs_router)


### PR DESCRIPTION
<!--PR 제목 : [ 이름 ] #이슈번호 - 구현 내용 -->

# 구현 목표
<!-- 이슈 번호 맵핑해주세요. 간단한 요약을 해주세요.-->
- #16 
- 가계부 기록 생성/(리스트)조회 기능 구현

# 변경 사항
<!--관련 없는 내용을 지워주세요-->

- [x] 기능 추가
- [ ] 셋업 
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 코드리뷰 반영
- [ ] 컨벤션 수정
- [ ] 레거시코드 제거 및 Breaking

<!--⬇ 변경사항을 자세히 작성합니다. ⬇-->
- 가계부 기록 생성 기능 구현
   - 인증/인가에 통과한 유저만 가계부 기록 생성 가능
   - 필수 입력값(가계부 기록의 제목, 가격, 가계부 정보(id), 카테고리 정보(id)) 확인
   - 선택 입력값(가계부 기록의 설명, 타입) 적용
- 가계부 기록 리스트 조회 기능 구현
   - 인증/인가에 통과한 유저만 본인의 가계부 기록 리스트 조회 가능
   - 부가기능:
      - 기록 검색기능
      - 기록 정렬기능
      - 기록 필터링기능
         - 사용중인/삭제된 기록을 기준으로 필터링 적용 가능
         - 타입을 기준으로 필터링 적용 가능
         - 카테고리를 기준으로 필터링 적용 가능(카테고리 복수선택 가능)
      - 페이지네이션 기능
   - 가계부 기록의 종합 데이터 반환(유저 닉네임, 가계부 예산, 총수입, 총지출, 가계부 기록)

# 테스트 여부
<!--테스트 통과 여부를 체크해주세요-->
- [x] TEST 

# 스크린샷 
<!--필요한 경우 첨부합니다-->

